### PR TITLE
Reanchoring doc example after language switch

### DIFF
--- a/source/themes/tempoiq_theme/static/js/multilang_examples.js
+++ b/source/themes/tempoiq_theme/static/js/multilang_examples.js
@@ -131,7 +131,16 @@
 
         base.onLanguageChanged = function (event) {
             if (event) event.preventDefault();
+            var ofsetFromTop = 80,
+                $body = $('body'),
+                scrollTop     = $body.scrollTop(),
+                elementOffset = base.$el.offset().top - ofsetFromTop,
+                distance = elementOffset - scrollTop;
+
             $(base).trigger("languageChanged", $(this).data("language"));
+            var newScrollTop = $('body').scrollTop(),
+                topPos = base.$el.offset().top;
+            $body.scrollTop(topPos - distance - ofsetFromTop);
         };
 
         base.setLanguage = function (lang) {

--- a/source/themes/tempoiq_theme/static/js/multilang_examples.js
+++ b/source/themes/tempoiq_theme/static/js/multilang_examples.js
@@ -138,9 +138,7 @@
                 distance = elementOffset - scrollTop;
 
             $(base).trigger("languageChanged", $(this).data("language"));
-            var newScrollTop = $('body').scrollTop(),
-                topPos = base.$el.offset().top;
-            $body.scrollTop(topPos - distance - ofsetFromTop);
+            $body.scrollTop(base.$el.offset().top - distance - ofsetFromTop);
         };
 
         base.setLanguage = function (lang) {


### PR DESCRIPTION
adding anchor hook callback to relocate view to same location on the screen as before the languages switched